### PR TITLE
fix Infinispan cache store handling

### DIFF
--- a/dmr/src/main/java/org/jboss/hal/dmr/ModelDescriptionConstants.java
+++ b/dmr/src/main/java/org/jboss/hal/dmr/ModelDescriptionConstants.java
@@ -56,6 +56,7 @@ public interface ModelDescriptionConstants {
     String ADMIN_OBJECTS = "admin-objects";
     String AJP_LISTENER = "ajp-listener";
     String ALLOWED = "allowed";
+    String ALLOW_RESOURCE_SERVICE_RESTART = "allow-resource-service-restart";
     String ALTERNATIVES = "alternatives";
     String ANY = "any";
     String ARCHIVE = "archive";


### PR DESCRIPTION
Fix for Infinispan cache store handling, adding a store requires the `allow-resource-service-restart` header (with the exception of file store but that seems to be a bug).

Also fixing the `reload` method, fetching selected profile fails in standalone mode.