### PR TITLE
Fix autocomplete intialization

### DIFF
--- a/ballroom/src/main/java/org/jboss/hal/ballroom/autocomplete/AutoComplete.java
+++ b/ballroom/src/main/java/org/jboss/hal/ballroom/autocomplete/AutoComplete.java
@@ -37,6 +37,7 @@ import static org.jboss.gwt.elemento.core.Elements.asHtmlElement;
 import static org.jboss.gwt.elemento.core.Elements.htmlElements;
 import static org.jboss.hal.ballroom.form.Form.State.EDITING;
 import static org.jboss.hal.resources.CSS.autocompleteSuggestions;
+import static org.jboss.hal.resources.CSS.formControl;
 
 /**
  * Java wrapper for <a href="https://github.com/Pixabay/JavaScript-autoComplete">javascript-auto-complete</a>
@@ -69,7 +70,7 @@ public class AutoComplete implements SuggestHandler, Attachable {
     @Override
     public void attach() {
         if (api == null) {
-            options.selector = formItemSelector();
+            options.selector = formItem().asElement(EDITING).getElementsByClassName(formControl).getAt(0);
             options.onSelect = (event, item, renderedItem) -> {
                 if (formItem() instanceof AbstractFormItem) {
                     ((AbstractFormItem) formItem()).onSuggest(item);

--- a/ballroom/src/main/java/org/jboss/hal/ballroom/autocomplete/Options.java
+++ b/ballroom/src/main/java/org/jboss/hal/ballroom/autocomplete/Options.java
@@ -20,10 +20,12 @@ import jsinterop.annotations.JsType;
 import static jsinterop.annotations.JsPackage.GLOBAL;
 import static org.jboss.hal.resources.UIConstants.OBJECT;
 
+import elemental2.dom.Element;
+
 @JsType(isNative = true, namespace = GLOBAL, name = OBJECT)
 public class Options {
 
-    public String selector;
+    public Element selector;
     public SourceFunction source;
     public int minChars;
     public int delay;


### PR DESCRIPTION
Autocomplete is broken in a Wizard (e.g. the Driver step in a Datasource Wizard). The JS component uses `document.querySelectorAll` to find the input but doesn't work because the element isn't part of the DOM yet. Wizard is inserting the elements after all Attachables have been attached.

This might a be problem for other components but I haven't checked.