### PR TITLE
fix NumberItem validation

### DIFF
--- a/ballroom/src/main/java/org/jboss/hal/ballroom/form/NumberItem.java
+++ b/ballroom/src/main/java/org/jboss/hal/ballroom/form/NumberItem.java
@@ -170,7 +170,7 @@ public class NumberItem extends AbstractFormItem<Long> {
 
     @Override
     public boolean isEmpty() {
-        return isExpressionValue() ? Strings.isNullOrEmpty(getExpressionValue()) : getValue() == null;
+        return Strings.isNullOrEmpty(isExpressionValue() ? getExpressionValue() : inputElement.value);
     }
 
     @Override


### PR DESCRIPTION
NumberItem with non-numerical value shouldn't return `isEmpty() == true`. The current behavior makes it fail RequiredValidation and pass NumberValidation, it should behave the opposite way.