### PR TITLE
Clear message fix

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/skeleton/HeaderPresenter.java
+++ b/app/src/main/java/org/jboss/hal/client/skeleton/HeaderPresenter.java
@@ -124,6 +124,9 @@ public class HeaderPresenter extends PresenterWidget<HeaderPresenter.MyView> imp
         void clearMessages();
         void hideReconnect();
 
+        default void onClearMessage() {};
+        default void onClearAllMessages() {};
+
         void selectTopLevelCategory(String nameToken);
         void updateLinks(FinderContext finderContext);
 
@@ -286,6 +289,14 @@ public class HeaderPresenter extends PresenterWidget<HeaderPresenter.MyView> imp
 
     void clearMessages() {
         getView().clearMessages();
+    }
+
+    void onClearAllMessages() {
+        getView().onClearAllMessages();
+    }
+
+    void onClearMessage() {
+        getView().onClearMessage();
     }
 
     void reconnect() {

--- a/app/src/main/java/org/jboss/hal/client/skeleton/HeaderView.java
+++ b/app/src/main/java/org/jboss/hal/client/skeleton/HeaderView.java
@@ -337,6 +337,18 @@ public abstract class HeaderView extends HalViewImpl implements HeaderPresenter.
     @Override
     public void clearMessages() {
         messageSink.clear();
+    }
+
+    @Override
+    public void onClearMessage() {
+        if (messageSink.getMessageCount() == 0) {
+            messagesIcon.classList.remove("fa-bell"); //NON-NLS
+            messagesIcon.classList.add("fa-bell-o"); //NON-NLS
+        }
+    }
+
+    @Override
+    public void onClearAllMessages() {
         messagesIcon.classList.remove("fa-bell"); //NON-NLS
         messagesIcon.classList.add("fa-bell-o"); //NON-NLS
     }

--- a/app/src/main/java/org/jboss/hal/client/skeleton/MessageSink.java
+++ b/app/src/main/java/org/jboss/hal/client/skeleton/MessageSink.java
@@ -55,12 +55,12 @@ class MessageSink implements IsElement, HasPresenter<HeaderPresenter> {
                         .add(div().css(panel, panelDefault)
                                 .add(panelHeader = div().css(panelHeading).asElement())
                                 .add(div().css(panelCollapse, collapse, in)
-                                        .add(panelBody = div().css(CSS.panelBody)
-                                                .add(div().css(drawerPfAction)
-                                                        .add(clear = button(resources.constants().clearMessages())
-                                                                .css(btn, btnLink, btnBlock, clickable)
-                                                                .asElement()))
-                                                .asElement()))))
+                                        .add(panelBody = div().css(CSS.panelBody).asElement())
+                                        .add(div().css(drawerPfAction)
+                                                .add(clear = button(resources.constants().clearMessages())
+                                                            .css(btn, btnLink, btnBlock, clickable)
+                                                            .asElement()))
+                                                .asElement())))
                 .asElement();
 
         bind(clear, click, event -> presenter.clearMessages());

--- a/app/src/main/java/org/jboss/hal/client/skeleton/MessageSink.java
+++ b/app/src/main/java/org/jboss/hal/client/skeleton/MessageSink.java
@@ -63,7 +63,7 @@ class MessageSink implements IsElement, HasPresenter<HeaderPresenter> {
                                                 .asElement())))
                 .asElement();
 
-        bind(clear, click, event -> presenter.clearMessages());
+        bind(clear, click, event -> this.clear());
         Elements.setVisible(panelHeader, false); // not used
     }
 
@@ -77,10 +77,14 @@ class MessageSink implements IsElement, HasPresenter<HeaderPresenter> {
         return root;
     }
 
+    int getMessageCount() {
+        return (int) panelBody.childElementCount;
+    }
+
     void add(Message message) {
         MessageSinkElement element = new MessageSinkElement(this, message, resources);
         panelBody.insertBefore(element.asElement(), panelBody.firstElementChild);
-        int messageCount = (int) panelBody.childElementCount;
+        int messageCount = getMessageCount();
         if (messageCount > SIZE) {
             panelBody.removeChild(panelBody.lastElementChild);
         }
@@ -91,14 +95,16 @@ class MessageSink implements IsElement, HasPresenter<HeaderPresenter> {
         Element element = document.getElementById(id);
         Elements.failSafeRemove(panelBody, element);
         updateHeader();
+        presenter.onClearMessage();
     }
 
     void clear() {
         Elements.removeChildrenFrom(panelBody);
         updateHeader();
+        presenter.onClearAllMessages();
     }
 
     private void updateHeader() {
-        messagesHeader.textContent = resources.messages().messages((int) panelBody.childElementCount);
+        messagesHeader.textContent = resources.messages().messages(getMessageCount());
     }
 }


### PR DESCRIPTION
In notification drawer the "clear message" button is inside the message area so it counts as a message and when you click it it removes itself.

As for the second commit it seems to me there isn't a clear separation of concerns between the MessageSink and the presenter/view - the clear button would call the presenter which would then call the MessageSink instead of the MessageSink simply notifying the presenter that messages have been cleared. I've also added handling for removing single messages.