### PR TITLE
Refactor Flow in favour of RX 

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/accesscontrol/AssignmentColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/accesscontrol/AssignmentColumn.java
@@ -235,7 +235,7 @@ public class AssignmentColumn extends FinderColumn<Assignment> {
         return column -> {
             Principal principal = findPrincipal(getFinder().getContext().getPath());
             if (principal != null) {
-                series(progress.get(), new FlowContext(),
+                series(new FlowContext(progress.get()),
                         new CheckRoleMapping(dispatcher, role),
                         new AddRoleMapping(dispatcher, role, status -> status == 404),
                         new AddAssignment(dispatcher, role, principal, include))

--- a/app/src/main/java/org/jboss/hal/client/accesscontrol/MembershipColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/accesscontrol/MembershipColumn.java
@@ -242,7 +242,7 @@ public class MembershipColumn extends FinderColumn<Assignment> {
         return column -> {
             Role role = findRole(getFinder().getContext().getPath());
             if (role != null) {
-                series(progress.get(), new FlowContext(), new CheckRoleMapping(dispatcher, role),
+                series(new FlowContext(progress.get()), new CheckRoleMapping(dispatcher, role),
                         new AddRoleMapping(dispatcher, role, status -> status == 404),
                         new AddAssignment(dispatcher, role, principal, include))
                 .subscribe(new org.jboss.hal.core.SuccessfulOutcome<FlowContext>(eventBus, resources) {

--- a/app/src/main/java/org/jboss/hal/client/accesscontrol/PrincipalColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/accesscontrol/PrincipalColumn.java
@@ -214,7 +214,7 @@ class PrincipalColumn extends FinderColumn<Principal> {
         collectTasks(tasks, type, name, true, model, INCLUDE);
         collectTasks(tasks, type, name, false, model, EXCLUDE);
         if (!tasks.isEmpty()) {
-            series(progress.get(), new FlowContext(), tasks)
+            series(new FlowContext(progress.get()), tasks)
                     .subscribe(new SuccessfulOutcome<FlowContext>(eventBus, resources) {
                         @Override
                         public void onSuccess(FlowContext context) {

--- a/app/src/main/java/org/jboss/hal/client/accesscontrol/RoleColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/accesscontrol/RoleColumn.java
@@ -299,7 +299,7 @@ public class RoleColumn extends FinderColumn<Role> {
                 tasks.add(new AddRoleMapping(dispatcher, transientRole, status -> status == 404));
                 tasks.add(new ModifyIncludeAll(dispatcher, transientRole, true));
             }
-            series(progress.get(), new FlowContext(), tasks)
+            series(new FlowContext(progress.get()), tasks)
                     .subscribe(new SuccessfulOutcome<FlowContext>(eventBus, resources) {
                         @Override
                         public void onSuccess(FlowContext context) {
@@ -330,7 +330,7 @@ public class RoleColumn extends FinderColumn<Role> {
         modelNode.get(INCLUDE_ALL).set(role.isIncludeAll());
         new ModifyResourceDialog(resources.messages().modifyResourceTitle(resources.constants().role()),
                 form, (frm, changedValues) ->
-                series(progress.get(), new FlowContext(),
+                series(new FlowContext(progress.get()),
                         new CheckRoleMapping(dispatcher, role),
                         new AddRoleMapping(dispatcher, role, status -> status == 404),
                         new ModifyIncludeAll(dispatcher, role, frm.getModel().get(INCLUDE_ALL).asBoolean()))
@@ -383,7 +383,7 @@ public class RoleColumn extends FinderColumn<Role> {
                 tasks.add(new AddRoleMapping(dispatcher, role, status -> status == 404));
                 tasks.add(new ModifyIncludeAll(dispatcher, role, includesAll));
             }
-            series(progress.get(), new FlowContext(), tasks)
+            series(new FlowContext(progress.get()), tasks)
                     .subscribe(new SuccessfulOutcome<FlowContext>(eventBus, resources) {
                         @Override
                         public void onSuccess(FlowContext context) {
@@ -411,7 +411,7 @@ public class RoleColumn extends FinderColumn<Role> {
         tasks.add(new RemoveRoleMapping(dispatcher, role, status -> status == 200));
         tasks.add(new RemoveScopedRole(dispatcher, role));
 
-        series(progress.get(), new FlowContext(), tasks)
+        series(new FlowContext(progress.get()), tasks)
                 .subscribe(new SuccessfulOutcome<FlowContext>(eventBus, resources) {
                     @Override
                     public void onSuccess(FlowContext context) {

--- a/app/src/main/java/org/jboss/hal/client/bootstrap/HalBootstrapper.java
+++ b/app/src/main/java/org/jboss/hal/client/bootstrap/HalBootstrapper.java
@@ -66,7 +66,7 @@ public class HalBootstrapper implements Bootstrapper {
 
         endpointManager.select(() -> {
             LoadingPanel.get().on();
-            series(Progress.NOOP, new FlowContext(), bootstrapFunctions.functions())
+            series(new FlowContext(), bootstrapFunctions.functions())
                     .subscribe(new Outcome<FlowContext>() {
                         @Override
                         public void onSuccess(FlowContext context) {

--- a/app/src/main/java/org/jboss/hal/client/configuration/PathsAutoComplete.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/PathsAutoComplete.java
@@ -32,7 +32,6 @@ import org.jboss.hal.dmr.ResourceAddress;
 import org.jboss.hal.dmr.dispatch.Dispatcher;
 import org.jboss.hal.flow.FlowContext;
 import org.jboss.hal.flow.Outcome;
-import org.jboss.hal.flow.Progress;
 import org.jboss.hal.json.JsonObject;
 import org.jboss.hal.meta.StatementContext;
 import org.jetbrains.annotations.NonNls;
@@ -43,7 +42,7 @@ import static org.jboss.hal.dmr.ModelDescriptionConstants.CHILD_TYPE;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.NAME;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.PROFILE_NAME;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.READ_CHILDREN_NAMES_OPERATION;
-import static org.jboss.hal.flow.Flow.single;
+import static org.jboss.hal.flow.Flow.series;
 
 /**
  * Special auto complete class for paths. In standalone mode or in case there's no selected profile the paths are read
@@ -69,7 +68,7 @@ public class PathsAutoComplete extends AutoComplete {
         if (environment.isStandalone() || statementContext.selectedProfile() == null) {
             operation = defaultOperation();
         } else {
-            single(Progress.NOOP, new FlowContext(),
+            series(new FlowContext(),
                     new TopologyTasks.RunningServersQuery(environment, dispatcher,
                             new ModelNode().set(PROFILE_NAME, statementContext.selectedProfile())))
             .subscribe(new Outcome<FlowContext>() {

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/DataSourceColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/DataSourceColumn.java
@@ -236,7 +236,7 @@ public class DataSourceColumn extends FinderColumn<DataSource> {
                             control.proceed();
                         });
 
-        series(progress.get(), new FlowContext(),
+        series(new FlowContext(progress.get()),
                 readDataSources,
                 new JdbcDriverTasks.ReadConfiguration(crud),
                 new TopologyTasks.RunningServersQuery(environment, dispatcher, environment.isStandalone()

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/JdbcDriverColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/JdbcDriverColumn.java
@@ -83,7 +83,7 @@ public class JdbcDriverColumn extends FinderColumn<JdbcDriver> {
 
         super(new FinderColumn.Builder<JdbcDriver>(finder, Ids.JDBC_DRIVER, Names.JDBC_DRIVER)
 
-                .itemsProvider((context, callback) -> series(progress.get(), new FlowContext(),
+                .itemsProvider((context, callback) -> series(new FlowContext(progress.get()),
                         new JdbcDriverTasks.ReadConfiguration(crud),
                         new TopologyTasks.RunningServersQuery(environment, dispatcher, environment.isStandalone()
                                 ? null

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/TestStep.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/TestStep.java
@@ -139,7 +139,7 @@ class TestStep extends WizardStep<Context, State> {
             }
         });
 
-        series(progress.get(), new FlowContext(), tasks)
+        series(new FlowContext(progress.get()), tasks)
                 .subscribe(new Outcome<FlowContext>() {
                     @Override
                     public void onError(FlowContext flowContext, Throwable error) {

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/jmx/JmxPresenter.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/jmx/JmxPresenter.java
@@ -125,7 +125,7 @@ public class JmxPresenter extends ApplicationFinderPresenter<JmxPresenter.MyView
         } else {
             changedValues.remove(HANDLER);
             Metadata metadata = metadataRegistry.lookup(AUDIT_LOG_TEMPLATE);
-            series(progress.get(), new FlowContext(),
+            series(new FlowContext(progress.get()),
                     new HandlerTasks.SaveAuditLog(dispatcher, statementContext, changedValues, metadata),
                     new HandlerTasks.ReadHandlers(dispatcher, statementContext),
                     new HandlerTasks.MergeHandler(dispatcher, statementContext, new HashSet<>(handler)))

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/messaging/DestinationPresenter.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/messaging/DestinationPresenter.java
@@ -188,7 +188,7 @@ public class DestinationPresenter
                 }
             };
 
-            series(progress.get(), new FlowContext(), check, add)
+            series(new FlowContext(progress.get()), check, add)
                     .subscribe(new SuccessfulOutcome<FlowContext>(getEventBus(), resources) {
                         @Override
                         public void onSuccess(FlowContext context) {
@@ -279,7 +279,7 @@ public class DestinationPresenter
                             }
                         };
 
-                        series(progress.get(), new FlowContext(),
+                        series(new FlowContext(progress.get()),
                                 removeRole, readRemainingRoles, removeSecuritySetting)
                                 .subscribe(new SuccessfulOutcome<FlowContext>(getEventBus(), resources) {
                                     @Override

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/remoting/RemotingPresenter.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/remoting/RemotingPresenter.java
@@ -441,7 +441,7 @@ public class RemotingPresenter
     private void failSafeCreatePolicy(String type, AddressTemplate securityTemplate, AddressTemplate policyTemplate,
             StatementContext statementContext) {
 
-        series(progress.get(), new FlowContext(),
+        series(new FlowContext(progress.get()),
                 new ResourceCheck(dispatcher, securityTemplate.resolve(statementContext)),
                 (context, control) -> {
                     int status = context.pop();

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/security/SecurityDomainPresenter.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/security/SecurityDomainPresenter.java
@@ -183,7 +183,7 @@ public class SecurityDomainPresenter
         // first check for (and add if necessary) the intermediate singleton
         // then add the final resource
         AddressTemplate singletonTemplate = SELECTED_SECURITY_DOMAIN_TEMPLATE.append(module.singleton);
-        series(progress.get(), new FlowContext(),
+        series(new FlowContext(progress.get()),
                 new ResourceCheck(dispatcher, singletonTemplate.resolve(statementContext)),
                 (context, control) -> {
                     int status = context.pop();

--- a/app/src/main/java/org/jboss/hal/client/deployment/ContentColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/deployment/ContentColumn.java
@@ -91,7 +91,6 @@ import static org.jboss.hal.core.finder.FinderColumn.RefreshMode.CLEAR_SELECTION
 import static org.jboss.hal.core.finder.FinderColumn.RefreshMode.RESTORE_SELECTION;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.*;
 import static org.jboss.hal.flow.Flow.series;
-import static org.jboss.hal.flow.Flow.single;
 import static org.jboss.hal.resources.CSS.fontAwesome;
 import static org.jboss.hal.resources.CSS.pfIcon;
 import static org.jboss.hal.spi.MessageEvent.fire;
@@ -131,8 +130,7 @@ public class ContentColumn extends FinderColumn<Content> {
             Resources resources) {
 
         super(new FinderColumn.Builder<Content>(finder, Ids.CONTENT, resources.constants().content())
-
-                .itemsProvider((context, callback) -> single(progress.get(), new FlowContext(),
+                .itemsProvider((context, callback) -> series(new FlowContext(progress.get()),
                         new LoadContent(dispatcher))
                         .subscribe(new Outcome<FlowContext>() {
                             @Override
@@ -297,7 +295,7 @@ public class ContentColumn extends FinderColumn<Content> {
                     wzd.showProgress(resources.constants().uploadInProgress(),
                             resources.messages().uploadInProgress(name));
 
-                    series(progress.get(), new FlowContext(),
+                    series(new FlowContext(progress.get()),
                             new CheckDeployment(dispatcher, name),
                             new UploadOrReplace(environment, dispatcher, name, runtimeName, context.file, false))
                             .subscribe(new Outcome<FlowContext>() {
@@ -324,7 +322,7 @@ public class ContentColumn extends FinderColumn<Content> {
     private void addUnmanaged() {
         Metadata metadata = metadataRegistry.lookup(CONTENT_TEMPLATE);
         AddUnmanagedDialog dialog = new AddUnmanagedDialog(metadata, resources,
-                (name, model) -> single(progress.get(), new FlowContext(),
+                (name, model) -> series(new FlowContext(progress.get()),
                         new AddUnmanagedDeployment(dispatcher, name, model))
                         .subscribe(new org.jboss.hal.core.SuccessfulOutcome<FlowContext>(eventBus, resources) {
                             @Override
@@ -346,7 +344,7 @@ public class ContentColumn extends FinderColumn<Content> {
                 .primary(resources.constants().replace(), () -> {
                     boolean valid = uploadElement.validate();
                     if (valid) {
-                        series(progress.get(), new FlowContext(),
+                        series(new FlowContext(progress.get()),
                                 new CheckDeployment(dispatcher, content.getName()),
                                 // To replace an existing content, the original name and runtime-name must be preserved.
                                 new UploadOrReplace(environment, dispatcher, content.getName(),

--- a/app/src/main/java/org/jboss/hal/client/deployment/DeploymentTasks.java
+++ b/app/src/main/java/org/jboss/hal/client/deployment/DeploymentTasks.java
@@ -485,7 +485,7 @@ class DeploymentTasks {
             }
 
             logger.debug("About to upload / update {} file(s): {}", files.getLength(), builder.toString());
-            series(progress.get(), new FlowContext(), tasks)
+            series(new FlowContext(progress.get()), tasks)
                     .subscribe(new UploadOutcome<>(column, eventBus, files, resources));
         }
     }
@@ -511,7 +511,7 @@ class DeploymentTasks {
 
             logger.debug("About to upload and deploy {} file(s): {} to server group {}",
                     files.getLength(), builder.toString(), serverGroup);
-            series(progress.get(), new FlowContext(), tasks)
+            series(new FlowContext(progress.get()), tasks)
                     .subscribe(new UploadOutcome<>(column, eventBus, files, resources));
         }
     }

--- a/app/src/main/java/org/jboss/hal/client/deployment/ServerGroupDeploymentColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/deployment/ServerGroupDeploymentColumn.java
@@ -90,7 +90,6 @@ import static org.jboss.hal.core.deployment.Deployment.Status.OK;
 import static org.jboss.hal.core.finder.FinderColumn.RefreshMode.RESTORE_SELECTION;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.*;
 import static org.jboss.hal.flow.Flow.series;
-import static org.jboss.hal.flow.Flow.single;
 import static org.jboss.hal.resources.CSS.pfIcon;
 
 /** The deployments of a server group. */
@@ -157,8 +156,8 @@ public class ServerGroupDeploymentColumn extends FinderColumn<ServerGroupDeploym
                 addActions);
         addColumnAction(columnActionFactory.refresh(Ids.SERVER_GROUP_DEPLOYMENT_REFRESH));
 
-        ItemsProvider<ServerGroupDeployment> itemsProvider = (context, callback) -> series(progress.get(),
-                new FlowContext(),
+        ItemsProvider<ServerGroupDeployment> itemsProvider = (context, callback) -> series(
+                new FlowContext(progress.get()),
                 new ReadServerGroupDeployments(environment, dispatcher, statementContext.selectedServerGroup()),
                 new RunningServersQuery(environment, dispatcher,
                         new ModelNode().set(SERVER_GROUP, statementContext.selectedServerGroup())),
@@ -308,7 +307,7 @@ public class ServerGroupDeploymentColumn extends FinderColumn<ServerGroupDeploym
                     wzd.showProgress(resources.constants().deploymentInProgress(),
                             resources.messages().deploymentInProgress(name));
 
-                    series(progress.get(), new FlowContext(),
+                    series(new FlowContext(progress.get()),
                             new CheckDeployment(dispatcher, name),
                             new UploadOrReplace(environment, dispatcher, name, runtimeName, context.file, false),
                             new AddServerGroupDeployment(environment, dispatcher, name, runtimeName,
@@ -382,7 +381,7 @@ public class ServerGroupDeploymentColumn extends FinderColumn<ServerGroupDeploym
                 }
             }
         };
-        single(progress.get(), new FlowContext(), new LoadContent(dispatcher)).subscribe(outcome);
+        series(new FlowContext(progress.get()), new LoadContent(dispatcher)).subscribe(outcome);
     }
 
     private void addUnmanaged() {
@@ -392,7 +391,7 @@ public class ServerGroupDeploymentColumn extends FinderColumn<ServerGroupDeploym
                     if (model != null) {
                         String serverGroup = statementContext.selectedServerGroup();
                         String runtimeName = model.get(RUNTIME_NAME).asString();
-                        series(progress.get(), new FlowContext(),
+                        series(new FlowContext(progress.get()),
                                 new AddUnmanagedDeployment(dispatcher, name, model),
                                 new AddServerGroupDeployment(environment, dispatcher, name, runtimeName, serverGroup))
                                 .subscribe(new SuccessfulOutcome<FlowContext>(eventBus, resources) {

--- a/app/src/main/java/org/jboss/hal/client/deployment/ServerGroupDeploymentPresenter.java
+++ b/app/src/main/java/org/jboss/hal/client/deployment/ServerGroupDeploymentPresenter.java
@@ -127,7 +127,7 @@ public class ServerGroupDeploymentPresenter extends
 
     @Override
     protected void reload() {
-        series(progress.get(), new FlowContext(),
+        series(new FlowContext(progress.get()),
                 new ReadServerGroupDeployments(environment, dispatcher, serverGroup, deployment),
                 new RunningServersQuery(environment, dispatcher, new ModelNode().set(SERVER_GROUP, serverGroup)),
                 new LoadDeploymentsFromRunningServer(environment, dispatcher))

--- a/app/src/main/java/org/jboss/hal/client/deployment/StandaloneDeploymentColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/deployment/StandaloneDeploymentColumn.java
@@ -75,7 +75,6 @@ import static org.jboss.hal.client.deployment.wizard.UploadState.UPLOAD;
 import static org.jboss.hal.core.finder.FinderColumn.RefreshMode.RESTORE_SELECTION;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.*;
 import static org.jboss.hal.flow.Flow.series;
-import static org.jboss.hal.flow.Flow.single;
 import static org.jboss.hal.resources.CSS.fontAwesome;
 import static org.jboss.hal.resources.CSS.pfIcon;
 
@@ -248,7 +247,7 @@ public class StandaloneDeploymentColumn extends FinderColumn<Deployment> {
                     wzd.showProgress(resources.constants().deploymentInProgress(),
                             resources.messages().deploymentInProgress(name));
 
-                    series(progress.get(), new FlowContext(),
+                    series(new FlowContext(progress.get()),
                             new CheckDeployment(dispatcher, name),
                             new UploadOrReplace(environment, dispatcher, name, runtimeName, context.file,
                                     context.enabled))
@@ -276,7 +275,7 @@ public class StandaloneDeploymentColumn extends FinderColumn<Deployment> {
     private void addUnmanaged() {
         Metadata metadata = metadataRegistry.lookup(DEPLOYMENT_TEMPLATE);
         AddUnmanagedDialog dialog = new AddUnmanagedDialog(metadata, resources,
-                (name, model) -> single(progress.get(), new FlowContext(),
+                (name, model) -> series(new FlowContext(progress.get()),
                         new AddUnmanagedDeployment(dispatcher, name, model))
                         .subscribe(new SuccessfulOutcome<FlowContext>(eventBus, resources) {
                             @Override

--- a/app/src/main/java/org/jboss/hal/client/patching/HostPatchesColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/patching/HostPatchesColumn.java
@@ -62,7 +62,7 @@ import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
 import static org.jboss.hal.core.finder.FinderColumn.RefreshMode.RESTORE_SELECTION;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.*;
-import static org.jboss.hal.flow.Flow.single;
+import static org.jboss.hal.flow.Flow.series;
 
 @Column(Ids.PATCHING_DOMAIN)
 @Requires(value = "/host=*/core-service=patching")
@@ -157,7 +157,7 @@ public class HostPatchesColumn extends FinderColumn<NamedNode> implements HostAc
 
                 .columnAction(columnActionFactory.refresh(Ids.HOST_REFRESH))
 
-                .itemsProvider((context, callback) -> single(progress.get(), new FlowContext(),
+                .itemsProvider((context, callback) -> series(new FlowContext(progress.get()),
                         new AvailableHosts(dispatcher))
                         .subscribe(new Outcome<FlowContext>() {
                             @Override

--- a/app/src/main/java/org/jboss/hal/client/patching/wizard/ApplyPatchWizard.java
+++ b/app/src/main/java/org/jboss/hal/client/patching/wizard/ApplyPatchWizard.java
@@ -44,7 +44,7 @@ import static org.jboss.hal.client.patching.wizard.PatchState.CHECK_SERVERS;
 import static org.jboss.hal.client.patching.wizard.PatchState.CONFIGURE;
 import static org.jboss.hal.client.patching.wizard.PatchState.UPLOAD;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.*;
-import static org.jboss.hal.flow.Flow.single;
+import static org.jboss.hal.flow.Flow.series;
 
 public class ApplyPatchWizard {
 
@@ -164,7 +164,7 @@ public class ApplyPatchWizard {
                         String name = context.file.name;
                         wzd.showProgress(resources.constants().patchInProgress(), messages.patchInProgress(name));
 
-                        single(progress.get(), new FlowContext(),
+                        series(new FlowContext(progress.get()),
                                 new UploadPatch(statementContext, dispatcher, serverActions, context))
                                 .subscribe(new Outcome<FlowContext>() {
                                     @Override

--- a/app/src/main/java/org/jboss/hal/client/patching/wizard/RollbackWizard.java
+++ b/app/src/main/java/org/jboss/hal/client/patching/wizard/RollbackWizard.java
@@ -43,7 +43,7 @@ import static org.jboss.hal.client.patching.PatchesColumn.PATCHING_TEMPLATE;
 import static org.jboss.hal.client.patching.wizard.PatchState.CHECK_SERVERS;
 import static org.jboss.hal.client.patching.wizard.PatchState.ROLLBACK;
 import static org.jboss.hal.dmr.ModelDescriptionConstants.*;
-import static org.jboss.hal.flow.Flow.single;
+import static org.jboss.hal.flow.Flow.series;
 
 public class RollbackWizard {
 
@@ -163,7 +163,7 @@ public class RollbackWizard {
                         String name = context.patchId;
                         wzd.showProgress(resources.constants().rollbackInProgress(), messages.rollbackInProgress(name));
 
-                        single(progress.get(), new FlowContext(),
+                        series(new FlowContext(progress.get()),
                                 new RollbackTask(statementContext, dispatcher, serverActions, context))
                                 .subscribe(new Outcome<FlowContext>() {
                                     @Override

--- a/app/src/main/java/org/jboss/hal/client/runtime/TopologyPreview.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/TopologyPreview.java
@@ -297,7 +297,7 @@ class TopologyPreview extends PreviewContent<StaticItem> implements HostActionHa
         // show the loading indicator if the dmr operation takes too long
         double timeoutHandle = setTimeout((o) -> Elements.setVisible(loadingSection, true),
                 UIConstants.MEDIUM_TIMEOUT);
-        series(progress.get(), new FlowContext(),
+        series(new FlowContext(progress.get()),
                 new TopologyTasks.Topology(environment, dispatcher),
                 new TopologyTasks.TopologyStartedServers(environment, dispatcher))
                 .subscribe(new Outcome<FlowContext>() {
@@ -347,7 +347,7 @@ class TopologyPreview extends PreviewContent<StaticItem> implements HostActionHa
     }
 
     private void updateServer(Server server) {
-        series(progress.get(), new FlowContext(),
+        series(new FlowContext(progress.get()),
                 // TODO Include function to read server boot errors
                 new TopologyTasks.HostWithServerConfigs(server.getHost(), dispatcher),
                 new TopologyTasks.HostStartedServers(dispatcher),

--- a/app/src/main/java/org/jboss/hal/client/runtime/group/ServerGroupColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/group/ServerGroupColumn.java
@@ -87,7 +87,7 @@ public class ServerGroupColumn extends FinderColumn<ServerGroup>
                         AddressTemplate.of("/server-group=*"), Ids::serverGroup))
                 .columnAction(columnActionFactory.refresh(Ids.SERVER_GROUP_REFRESH))
 
-                .itemsProvider((context, callback) -> series(progress.get(), new FlowContext(),
+                .itemsProvider((context, callback) -> series(new FlowContext(progress.get()),
                         new TopologyTasks.ServerGroupsWithServerConfigs(environment, dispatcher),
                         new TopologyTasks.ServerGroupsStartedServers(environment, dispatcher))
                         .subscribe(new Outcome<FlowContext>() {

--- a/app/src/main/java/org/jboss/hal/client/runtime/host/HostColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/host/HostColumn.java
@@ -140,7 +140,7 @@ public class HostColumn extends FinderColumn<Host> implements HostActionHandler,
                 .build());
         addColumnActions(Ids.HOST_PRUNE_ACTIONS, pfIcon("remove"), resources.constants().prune(), pruneActions);
 
-        ItemsProvider<Host> itemsProvider = (context, callback) -> series(progress.get(), new FlowContext(),
+        ItemsProvider<Host> itemsProvider = (context, callback) -> series(new FlowContext(progress.get()),
                 new TopologyTasks.HostsWithServerConfigs(environment, dispatcher),
                 new TopologyTasks.HostsStartedServers(environment, dispatcher))
                 .subscribe(new Outcome<FlowContext>() {

--- a/app/src/main/java/org/jboss/hal/client/runtime/server/ServerColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/server/ServerColumn.java
@@ -239,7 +239,7 @@ public class ServerColumn extends FinderColumn<Server> implements ServerActionHa
                 };
             }
 
-            series(progress.get(), new FlowContext(),
+            series(new FlowContext(progress.get()),
                     serverConfigsFn, new TopologyTasks.TopologyStartedServers(environment, dispatcher))
                     .subscribe(new Outcome<FlowContext>() {
                         @Override

--- a/app/src/main/java/org/jboss/hal/client/runtime/server/ServerPresenter.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/server/ServerPresenter.java
@@ -184,7 +184,7 @@ public class ServerPresenter
             }
         };
 
-        series(progress.get(), new FlowContext(), serverConfigFn, serverRuntimeFn)
+        series(new FlowContext(progress.get()), serverConfigFn, serverRuntimeFn)
                 .subscribe(new SuccessfulOutcome<FlowContext>(getEventBus(), resources) {
                     @Override
                     public void onSuccess(FlowContext context) {

--- a/app/src/main/java/org/jboss/hal/client/runtime/subsystem/messaging/JmsQueuePresenter.java
+++ b/app/src/main/java/org/jboss/hal/client/runtime/subsystem/messaging/JmsQueuePresenter.java
@@ -177,7 +177,7 @@ public class JmsQueuePresenter extends ApplicationFinderPresenter<JmsQueuePresen
                     });
                 }
             };
-            series(progress.get(), new FlowContext(), count, list)
+            series(new FlowContext(progress.get()), count, list)
                     .subscribe(new SuccessfulOutcome<FlowContext>(getEventBus(), resources) {
                         @Override
                         public void onSuccess(FlowContext context) {

--- a/app/src/main/java/org/jboss/hal/client/tools/MacroEditorPresenter.java
+++ b/app/src/main/java/org/jboss/hal/client/tools/MacroEditorPresenter.java
@@ -132,7 +132,7 @@ public class MacroEditorPresenter
         List<MacroOperationTask> tasks = macro.getOperations().stream()
                 .map(operation -> new MacroOperationTask(dispatcher, operation)).collect(toList());
         getView().disableMacro(macro);
-        series(progress.get(), new FlowContext(), tasks)
+        series(new FlowContext(progress.get()), tasks)
                 .subscribe(new Outcome<FlowContext>() {
                     @Override
                     public void onError(FlowContext context, Throwable error) {

--- a/core/src/main/java/org/jboss/hal/core/PropertiesOperations.java
+++ b/core/src/main/java/org/jboss/hal/core/PropertiesOperations.java
@@ -341,7 +341,7 @@ public class PropertiesOperations {
             Composite operations, String psr, Map<String, String> properties, Callback callback) {
 
         // TODO Check if the steps can be replaced with a composite operation
-        series(progress.get(), new FlowContext(),
+        series(new FlowContext(progress.get()),
                 (context, control) -> {
                     if (operations.isEmpty()) {
                         control.proceed();

--- a/core/src/main/java/org/jboss/hal/core/finder/Finder.java
+++ b/core/src/main/java/org/jboss/hal/core/finder/Finder.java
@@ -489,7 +489,7 @@ public class Finder implements IsElement, Attachable {
             List<RefreshTask> tasks = stream(path.spliterator(), false)
                     .map(segment -> new RefreshTask(new FinderSegment(segment.getColumnId(), segment.getItemId())))
                     .collect(toList());
-            series(progress.get(), new FlowContext(), tasks)
+            series(new FlowContext(progress.get()), tasks)
                     .subscribe(new Outcome<FlowContext>() {
                         @Override
                         public void onError(FlowContext context, Throwable error) {}
@@ -556,7 +556,7 @@ public class Finder implements IsElement, Attachable {
             List<SelectTask> tasks = stream(path.spliterator(), false)
                     .map(segment -> new SelectTask(new FinderSegment(segment.getColumnId(), segment.getItemId())))
                     .collect(toList());
-            series(progress.get(), new FlowContext(), tasks)
+            series(new FlowContext(progress.get()), tasks)
             .subscribe(new Outcome<FlowContext>() {
                 @Override
                 public void onError(FlowContext context, Throwable error) {

--- a/core/src/main/java/org/jboss/hal/core/modelbrowser/ModelBrowser.java
+++ b/core/src/main/java/org/jboss/hal/core/modelbrowser/ModelBrowser.java
@@ -297,7 +297,7 @@ public class ModelBrowser implements IsElement<HTMLElement> {
             List<OpenNodeTask> tasks = previousFilter.parents.stream()
                     .map(OpenNodeTask::new)
                     .collect(toList());
-            series(progress.get(), new FlowContext(), tasks)
+            series(new FlowContext(progress.get()), tasks)
                     .subscribe(new Outcome<FlowContext>() {
                         @Override
                         public void onError(FlowContext context, Throwable error) {

--- a/core/src/main/java/org/jboss/hal/core/runtime/server/ServerActions.java
+++ b/core/src/main/java/org/jboss/hal/core/runtime/server/ServerActions.java
@@ -666,7 +666,7 @@ public class ServerActions {
             callback.onSuccess(serverUrl);
 
         } else {
-            series(Progress.NOOP, new FlowContext(),
+            series(new FlowContext(),
                     new ReadSocketBindingGroup(standalone, serverGroup, dispatcher),
                     new ReadSocketBinding(standalone, host, server, dispatcher))
                     .subscribe(new Outcome<FlowContext>() {

--- a/flow/src/main/java/org/jboss/hal/flow/Flow.java
+++ b/flow/src/main/java/org/jboss/hal/flow/Flow.java
@@ -16,9 +16,6 @@
 package org.jboss.hal.flow;
 
 import java.util.Collection;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
-
 import rx.Observable;
 import rx.Single;
 
@@ -44,27 +41,5 @@ public interface Flow {
                 .doOnNext(n -> context.progress.tick())
                 .doOnTerminate(context.progress::finish)
                 .lastOrDefault(context).toSingle();
-    }
-
-    /** Executes a tasks until a condition is met. */
-    static <C extends IntervalContext<C>> Single<C> interval(C context) {
-        return Observable.interval(context.interval, TimeUnit.MILLISECONDS)
-                .flatMapSingle(n -> context.task.call(context))
-                .takeUntil(context.until::test)
-                .doOnSubscribe(context.progress::reset)
-                .doOnNext(n -> context.progress.tick())
-                .doOnTerminate(context.progress::finish)
-                .lastOrDefault(context).toSingle();
-    }
-
-    class IntervalContext<T extends IntervalContext> extends FlowContext {
-        public final int interval;
-        public final Predicate<T> until;
-        public final Task<T> task;
-        public IntervalContext(int interval, Predicate<T> until, Task<T> task) {
-            this.interval = interval;
-            this.until = until;
-            this.task = task;
-        }
     }
 }

--- a/flow/src/main/java/org/jboss/hal/flow/FlowContext.java
+++ b/flow/src/main/java/org/jboss/hal/flow/FlowContext.java
@@ -21,11 +21,16 @@ import java.util.Stack;
 
 /** General purpose context to be used inside a flow. Provides a stack and a map for sharing data between tasks. */
 public class FlowContext {
-
+    public final Progress progress;
     private final Stack<Object> stack;
     private final Map<String, Object> data;
 
     public FlowContext() {
+        this(Progress.NOOP);
+    }
+
+    public FlowContext(Progress progress) {
+        this.progress = progress;
         this.stack = new Stack<>();
         this.data = new HashMap<>();
     }

--- a/meta/src/main/java/org/jboss/hal/meta/processing/MetadataProcessor.java
+++ b/meta/src/main/java/org/jboss/hal/meta/processing/MetadataProcessor.java
@@ -49,7 +49,6 @@ import static java.util.Collections.singleton;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.jboss.hal.flow.Flow.series;
-import static org.jboss.hal.flow.Flow.single;
 
 /**
  * Reads resource {@link Metadata} using read-resource-description operations and stores it into the {@link
@@ -183,14 +182,10 @@ public class MetadataProcessor {
             List<RrdTask> allTasks = new ArrayList<>();
             allTasks.addAll(tasks);
             allTasks.addAll(optionalTasks);
-            if (tasks.size() == 1) {
-                single(progress, new FlowContext(), allTasks.get(0)).subscribe(outcome);
-            } else {
-                // Unfortunately we cannot use Async.parallel() here unless someone finds a way
-                // to unambiguously map parallel r-r-d operations to their results (multiple "step-1" results)
-                //noinspection SuspiciousToArrayCall
-                series(progress, new FlowContext(), allTasks).subscribe(outcome);
-            }
+            // Unfortunately we cannot use Async.parallel() here unless someone finds a way
+            // to unambiguously map parallel r-r-d operations to their results (multiple "step-1" results)
+            //noinspection SuspiciousToArrayCall
+            series(new FlowContext(progress), allTasks).subscribe(outcome);
         }
     }
 


### PR DESCRIPTION
* Remove Flow.single bc Flow.series with one task do the same.
* Remove Flow.interval as this is only used by TimeoutHandler. Repeating a task with RX is trivial, most of the logic is related to timeout.
* Refactor TimeoutHandler to use RX.

All these changes try to apply RX to the whole project progressively. There are various async strategies in the code, and there are really a lot of callbacks (finding for "interface .*Callback" returns more than 40 results, and a callback doesn't need to be an interface neither contains "Callback" in its name"). Also, there are many places applying the classing callback hell situation which can be solved with RX, but you need to unify all those callbacks with RX.

The problem is that in this phase the improvement is pretty limited and we are refactoring without no much improvement (and with the risk of adding bugs). Eventually, RX should make you API much easier to understand and compose, and safer bc RX will chain async calls, its subscription, and errors much better than current per-callback-type strategy.

In general, what I'm doing is trying to find isolated places with "async task" and wrapping it in a RX. For example here, the interval was an async task which will repeat some request until the result succeded or a timeout occurs. So I wrapped that task inside a Completable. After that, you can refactor everything inside the RX task, and this usually means just remove that utility as RX the most generalized situation, meaning RX is a lazy, reusable, async description of a task.

One of the most important places is the dispatcher, especially bc all other task involves the dispatcher, and the more RX types the easier to compose. Actually, any non RX type will require a bridge and so a possibility of error or subscription leaks, even a success leaks. This means that the life cycle of RX should be connected with the lifecycle of the callback, and in each connection/bridge, you can either lose information bc the callback do not support it, or a bug bc the mapping is not done correctly.