### PR TITLE
Minor changes on Dispatcher to see if it matches RX success/error

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/deployment/BrowseContentElement.java
+++ b/app/src/main/java/org/jboss/hal/client/deployment/BrowseContentElement.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Sets;
 import elemental2.core.Array;
 import elemental2.dom.HTMLElement;
 import elemental2.dom.HTMLImageElement;
+import java.util.function.Consumer;
 import org.jboss.gwt.elemento.core.Elements;
 import org.jboss.gwt.elemento.core.IsElement;
 import org.jboss.hal.ballroom.Attachable;
@@ -457,7 +458,7 @@ class BrowseContentElement implements IsElement, Attachable {
         }
     }
 
-    private void loadContent(ContentEntry contentEntry, Dispatcher.SuccessCallback<String> successCallback) {
+    private void loadContent(ContentEntry contentEntry, Consumer<String> successCallback) {
         if (!contentEntry.directory) {
             ResourceAddress address = new ResourceAddress().add(DEPLOYMENT, content);
             Operation operation = new Operation.Builder(address, READ_CONTENT)

--- a/app/src/main/java/org/jboss/hal/client/patching/wizard/ApplyPatchWizard.java
+++ b/app/src/main/java/org/jboss/hal/client/patching/wizard/ApplyPatchWizard.java
@@ -17,8 +17,8 @@ package org.jboss.hal.client.patching.wizard;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Consumer;
 import javax.inject.Provider;
-
 import org.jboss.hal.ballroom.wizard.Wizard;
 import org.jboss.hal.config.Environment;
 import org.jboss.hal.core.runtime.server.Server;
@@ -195,10 +195,10 @@ public class ApplyPatchWizard {
      * It is a good practice to apply/rollback a patch to a stopped server to prevent application and internal services
      * from failing.
      */
-    private void checkServersState(Dispatcher.SuccessCallback<List<Property>> callback) {
+    private void checkServersState(Consumer<List<Property>> callback) {
 
         if (environment.isStandalone()) {
-            callback.onSuccess(null);
+            callback.accept(null);
         } else {
 
             String host = statementContext.selectedHost();
@@ -221,9 +221,9 @@ public class ApplyPatchWizard {
                     }
                 }
                 if (anyServerStarted) {
-                    callback.onSuccess(servers);
+                    callback.accept(servers);
                 } else {
-                    callback.onSuccess(null);
+                    callback.accept(null);
                 }
             });
         }

--- a/app/src/main/java/org/jboss/hal/client/patching/wizard/RollbackWizard.java
+++ b/app/src/main/java/org/jboss/hal/client/patching/wizard/RollbackWizard.java
@@ -17,6 +17,7 @@ package org.jboss.hal.client.patching.wizard;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Consumer;
 import javax.inject.Provider;
 
 import org.jboss.hal.ballroom.wizard.Wizard;
@@ -194,9 +195,9 @@ public class RollbackWizard {
      * It is a good practice to apply/rollback a patch to a stopped server to prevent application and internal services
      * from failing.
      */
-    private void checkServersState(Dispatcher.SuccessCallback<List<Property>> callback) {
+    private void checkServersState(Consumer<List<Property>> callback) {
         if (environment.isStandalone()) {
-            callback.onSuccess(null);
+            callback.accept(null);
         } else {
 
             String host = statementContext.selectedHost();
@@ -219,9 +220,9 @@ public class RollbackWizard {
                     }
                 }
                 if (anyServerStarted) {
-                    callback.onSuccess(servers);
+                    callback.accept(servers);
                 } else {
-                    callback.onSuccess(null);
+                    callback.accept(null);
                 }
             });
         }

--- a/core/src/main/java/org/jboss/hal/core/expression/ExpressionResolver.java
+++ b/core/src/main/java/org/jboss/hal/core/expression/ExpressionResolver.java
@@ -81,8 +81,8 @@ public class ExpressionResolver implements ResolveExpressionEvent.ResolveExpress
             Operation operation = new Operation.Builder(ResourceAddress.root(), RESOLVE_EXPRESSION_ON_DOMAIN)
                     .param(EXPRESSION, expression.toString())
                     .build();
-            dispatcher.execute(operation, payload -> payload.get(SERVER_GROUPS),
-                    (serverGroups) -> callback.onSuccess(parseServerGroups(serverGroups)),
+            dispatcher.execute(operation,
+                    (res) -> callback.onSuccess(parseServerGroups(res.get(SERVER_GROUPS))),
                     (op1, failure) -> callback.onFailure(new RuntimeException(failure)),
                     (op2, exception) -> callback.onFailure(exception));
         }

--- a/core/src/main/java/org/jboss/hal/core/runtime/group/ServerGroupActions.java
+++ b/core/src/main/java/org/jboss/hal/core/runtime/group/ServerGroupActions.java
@@ -100,7 +100,7 @@ public class ServerGroupActions {
     }
 
 
-    private class ServerGroupFailedCallback implements Dispatcher.FailedCallback {
+    private class ServerGroupFailedCallback implements Dispatcher.OnFail {
 
         private final ServerGroup serverGroup;
         private final List<Server> servers;
@@ -120,7 +120,7 @@ public class ServerGroupActions {
     }
 
 
-    private class ServerGroupExceptionCallback implements Dispatcher.ExceptionCallback {
+    private class ServerGroupExceptionCallback implements Dispatcher.OnError {
 
         private final ServerGroup serverGroup;
         private final List<Server> servers;

--- a/core/src/main/java/org/jboss/hal/core/runtime/host/HostActions.java
+++ b/core/src/main/java/org/jboss/hal/core/runtime/host/HostActions.java
@@ -63,7 +63,7 @@ import static org.jboss.hal.resources.UIConstants.SHORT_TIMEOUT;
 
 public class HostActions {
 
-    private class HostFailedCallback implements Dispatcher.FailedCallback {
+    private class HostFailedCallback implements Dispatcher.OnFail {
 
         private final Host host;
         private final List<Server> servers;
@@ -82,7 +82,7 @@ public class HostActions {
     }
 
 
-    private class HostExceptionCallback implements Dispatcher.ExceptionCallback {
+    private class HostExceptionCallback implements Dispatcher.OnError {
 
         private final Host host;
         private final List<Server> servers;

--- a/core/src/main/java/org/jboss/hal/core/runtime/server/ServerActions.java
+++ b/core/src/main/java/org/jboss/hal/core/runtime/server/ServerActions.java
@@ -53,8 +53,8 @@ import org.jboss.hal.dmr.Operation;
 import org.jboss.hal.dmr.Property;
 import org.jboss.hal.dmr.ResourceAddress;
 import org.jboss.hal.dmr.dispatch.Dispatcher;
-import org.jboss.hal.dmr.dispatch.Dispatcher.ExceptionCallback;
-import org.jboss.hal.dmr.dispatch.Dispatcher.FailedCallback;
+import org.jboss.hal.dmr.dispatch.Dispatcher.OnError;
+import org.jboss.hal.dmr.dispatch.Dispatcher.OnFail;
 import org.jboss.hal.flow.FlowContext;
 import org.jboss.hal.flow.Outcome;
 import org.jboss.hal.flow.Progress;
@@ -143,7 +143,7 @@ public class ServerActions {
     }
 
 
-    private class ServerFailedCallback implements FailedCallback {
+    private class ServerFailedCallback implements OnFail {
 
         private final Server server;
         private final SafeHtml errorMessage;
@@ -160,7 +160,7 @@ public class ServerActions {
     }
 
 
-    private class ServerExceptionCallback implements ExceptionCallback {
+    private class ServerExceptionCallback implements OnError {
 
         private final Server server;
         private final SafeHtml errorMessage;
@@ -266,7 +266,7 @@ public class ServerActions {
                                 .param(RECURSIVE, true)
                                 .build();
 
-                        dispatcher.execute(opReadServer, new Dispatcher.OperationCallback() {
+                        dispatcher.execute(opReadServer, new Dispatcher.OnSuccess() {
                             @Override
                             public void onSuccess(final ModelNode newServerModel) {
 

--- a/dmr/src/main/java/org/jboss/hal/dmr/dispatch/ExceptionalFlowCallback.java
+++ b/dmr/src/main/java/org/jboss/hal/dmr/dispatch/ExceptionalFlowCallback.java
@@ -19,7 +19,7 @@ import org.jboss.hal.dmr.Operation;
 import org.jboss.hal.flow.Control;
 import org.jboss.hal.flow.FlowContext;
 
-public class ExceptionalFlowCallback<C extends FlowContext> implements Dispatcher.ExceptionCallback {
+public class ExceptionalFlowCallback<C extends FlowContext> implements Dispatcher.OnError {
 
     private final Control control;
 

--- a/dmr/src/main/java/org/jboss/hal/dmr/dispatch/FailedFlowCallback.java
+++ b/dmr/src/main/java/org/jboss/hal/dmr/dispatch/FailedFlowCallback.java
@@ -19,7 +19,7 @@ import org.jboss.hal.dmr.Operation;
 import org.jboss.hal.flow.Control;
 import org.jboss.hal.flow.FlowContext;
 
-public class FailedFlowCallback<C extends FlowContext> implements Dispatcher.FailedCallback {
+public class FailedFlowCallback<C extends FlowContext> implements Dispatcher.OnFail {
 
     private final Control control;
 


### PR DESCRIPTION
See commit messages. The OnError and OnFailure renaming were pretty unnecessary, but it makes all method definition to enter in one line 😉. And all those callbacks should be removed eventually.