### PR TITLE
Change Task to use Completable and change Flow to use Func1

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/remoting/RemotingPresenter.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/remoting/RemotingPresenter.java
@@ -44,6 +44,7 @@ import org.jboss.hal.dmr.ResourceCheck;
 import org.jboss.hal.dmr.dispatch.Dispatcher;
 import org.jboss.hal.flow.FlowContext;
 import org.jboss.hal.flow.Progress;
+import org.jboss.hal.flow.Task;
 import org.jboss.hal.meta.AddressTemplate;
 import org.jboss.hal.meta.Metadata;
 import org.jboss.hal.meta.MetadataRegistry;
@@ -443,7 +444,7 @@ public class RemotingPresenter
 
         series(new FlowContext(progress.get()),
                 new ResourceCheck(dispatcher, securityTemplate.resolve(statementContext)),
-                (context, control) -> {
+                (Task<FlowContext>) (context, control) -> {
                     int status = context.pop();
                     if (status == 200) {
                         control.proceed();
@@ -453,7 +454,7 @@ public class RemotingPresenter
                         dispatcher.executeInFlow(control, operation, result -> control.proceed());
                     }
                 },
-                (context, control) -> {
+                (Task<FlowContext>) (context, control) -> {
                     Operation operation = new Operation.Builder(policyTemplate.resolve(statementContext), ADD).build();
                     dispatcher.executeInFlow(control, operation, result -> control.proceed());
                 })

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/security/SecurityDomainPresenter.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/security/SecurityDomainPresenter.java
@@ -44,6 +44,7 @@ import org.jboss.hal.dmr.ResourceCheck;
 import org.jboss.hal.dmr.dispatch.Dispatcher;
 import org.jboss.hal.flow.FlowContext;
 import org.jboss.hal.flow.Progress;
+import org.jboss.hal.flow.Task;
 import org.jboss.hal.meta.AddressTemplate;
 import org.jboss.hal.meta.Metadata;
 import org.jboss.hal.meta.MetadataRegistry;
@@ -185,7 +186,7 @@ public class SecurityDomainPresenter
         AddressTemplate singletonTemplate = SELECTED_SECURITY_DOMAIN_TEMPLATE.append(module.singleton);
         series(new FlowContext(progress.get()),
                 new ResourceCheck(dispatcher, singletonTemplate.resolve(statementContext)),
-                (context, control) -> {
+                (Task<FlowContext>) (context, control) -> {
                     int status = context.pop();
                     if (status == 200) {
                         control.proceed();

--- a/core/src/main/java/org/jboss/hal/core/PropertiesOperations.java
+++ b/core/src/main/java/org/jboss/hal/core/PropertiesOperations.java
@@ -342,7 +342,7 @@ public class PropertiesOperations {
 
         // TODO Check if the steps can be replaced with a composite operation
         series(new FlowContext(progress.get()),
-                (context, control) -> {
+                (Task<FlowContext>) (context, control) -> {
                     if (operations.isEmpty()) {
                         control.proceed();
                     } else {

--- a/dmr/src/main/java/org/jboss/hal/dmr/dispatch/DispatchError.java
+++ b/dmr/src/main/java/org/jboss/hal/dmr/dispatch/DispatchError.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.hal.dmr.dispatch;
+
+import org.jboss.hal.dmr.Operation;
+
+public class DispatchError extends Exception {
+    private final Operation operation;
+    private final int statusCode;
+
+    DispatchError(Operation operation, String message, int statusCode) {
+        super(message + " Status Code " + statusCode);
+        this.operation = operation;
+        this.statusCode = statusCode;
+    }
+
+    public Operation getOperation() {
+        return operation;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+}

--- a/dmr/src/main/java/org/jboss/hal/dmr/dispatch/DispatchFailure.java
+++ b/dmr/src/main/java/org/jboss/hal/dmr/dispatch/DispatchFailure.java
@@ -15,20 +15,17 @@
  */
 package org.jboss.hal.dmr.dispatch;
 
-/**
- * @author Heiko Braun
- * @date 9/17/13
- */
-public class DispatchException extends Exception {
+import org.jboss.hal.dmr.Operation;
 
-    private final int statusCode;
+public class DispatchFailure extends Exception {
+    private final Operation operation;
 
-    DispatchException(String message, int statusCode) {
-        super(message + " Status Code " + statusCode);
-        this.statusCode = statusCode;
+    DispatchFailure(Operation operation, String message) {
+        super(message);
+        this.operation = operation;
     }
 
-    public int getStatusCode() {
-        return statusCode;
+    public Operation getOperation() {
+        return operation;
     }
 }

--- a/flow/src/main/java/org/jboss/hal/flow/FlowContext.java
+++ b/flow/src/main/java/org/jboss/hal/flow/FlowContext.java
@@ -23,7 +23,7 @@ import java.util.Stack;
  * General purpose context to be used inside a flow. Provides a {@linkplain Progress progress indicator}, a stack and a
  * map for sharing data between tasks.
  */
-public class FlowContext {
+public final class FlowContext {
 
     public final Progress progress;
     private final Stack<Object> stack;

--- a/flow/src/main/java/org/jboss/hal/flow/Task.java
+++ b/flow/src/main/java/org/jboss/hal/flow/Task.java
@@ -15,11 +15,11 @@
  */
 package org.jboss.hal.flow;
 
-import rx.Single;
+import rx.Completable;
 import rx.functions.Func1;
 
 /** Encapsulates one work item inside a flow */
-public interface Task<C> extends Func1<C, Single<C>> {
+public interface Task<C> extends Func1<C, Completable> {
 
     /**
      * Execute the task. Please make sure that you <strong>always</strong> call either {@link Control#proceed()} or
@@ -27,9 +27,9 @@ public interface Task<C> extends Func1<C, Single<C>> {
      */
     void execute(C context, Control control);
 
-    @Override default Single<C> call(C ctx) {
-        return Single.fromEmitter(emitter -> execute(ctx, new Control() {
-            @Override public void proceed() { emitter.onSuccess(ctx); }
+    @Override default Completable call(C ctx) {
+        return Completable.fromEmitter(emitter -> execute(ctx, new Control() {
+            @Override public void proceed() { emitter.onCompleted(); }
             @Override public void abort(String error) { emitter.onError(new FlowException(error, ctx)); }
         }));
     }


### PR DESCRIPTION
This will make it much easier to migrate Task to methods that return a Completable bc before this change you get forced to implement the Task.execute method but after this change, it is possible to remove the Task interface for each task class and use any method of type ´FlowContext -> Completable´.