### PR TITLE
Datasource validation

### DIFF
--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/DataSourceColumn.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/DataSourceColumn.java
@@ -294,7 +294,7 @@ public class DataSourceColumn extends FinderColumn<DataSource> {
         if (environment.isStandalone()) {
             ResourceAddress address = new ResourceAddress()
                     .add(SUBSYSTEM, DATASOURCES)
-                    .add(DATA_SOURCE, dataSource.getName());
+                    .add(dataSource.isXa() ? XA_DATA_SOURCE : DATA_SOURCE, dataSource.getName());
             Operation operation = new Operation.Builder(address, TEST_CONNECTION_IN_POOL).build();
             dispatcher.execute(operation,
                     result -> MessageEvent.fire(eventBus,

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/DriverStep.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/DriverStep.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import com.google.common.collect.Maps;
 import elemental2.dom.HTMLElement;
 import org.jboss.hal.ballroom.autocomplete.StaticAutoComplete;
+import org.jboss.hal.ballroom.form.ValidationResult;
 import org.jboss.hal.ballroom.wizard.WizardStep;
 import org.jboss.hal.core.datasource.JdbcDriver;
 import org.jboss.hal.core.mbui.form.ModelNodeForm;
@@ -50,6 +51,10 @@ class DriverStep extends WizardStep<Context, State> {
         if (!driversByName.isEmpty()) {
             form.getFormItem(DRIVER_NAME)
                     .registerSuggestHandler(new StaticAutoComplete(new ArrayList<>(driversByName.keySet())));
+            form.getFormItem(DRIVER_NAME)
+                    .addValidationHandler(value ->
+                        driversByName.keySet().contains(value) ? ValidationResult.OK : ValidationResult.invalid("Invalid driver name")
+                    );
         }
         registerAttachable(form);
     }

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/NamesStep.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/NamesStep.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import elemental2.dom.HTMLElement;
 import org.jboss.hal.ballroom.form.FormItem;
+import org.jboss.hal.ballroom.form.PatternValidation;
 import org.jboss.hal.ballroom.form.ValidationResult;
 import org.jboss.hal.ballroom.wizard.WizardStep;
 import org.jboss.hal.core.datasource.DataSource;
@@ -58,10 +59,7 @@ class NamesStep extends WizardStep<Context, State> {
                 })
                 .build();
 
-        form.getFormItem(JNDI_NAME).addValidationHandler(value ->
-                value.toString().matches("java:(jboss)?/.*") ? ValidationResult.OK
-                    : ValidationResult.invalid("JNDI name has to start with java:/ or java:jboss/")
-        );
+        form.getFormItem(JNDI_NAME).addValidationHandler(new PatternValidation.JNDINameValidation());
 
         registerAttachable(form);
     }

--- a/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/NamesStep.java
+++ b/app/src/main/java/org/jboss/hal/client/configuration/subsystem/datasource/wizard/NamesStep.java
@@ -57,6 +57,12 @@ class NamesStep extends WizardStep<Context, State> {
                     wizard().getContext().dataSource.update(form.getModel());
                 })
                 .build();
+
+        form.getFormItem(JNDI_NAME).addValidationHandler(value ->
+                value.toString().matches("java:(jboss)?/.*") ? ValidationResult.OK
+                    : ValidationResult.invalid("JNDI name has to start with java:/ or java:jboss/")
+        );
+
         registerAttachable(form);
     }
 

--- a/ballroom/src/main/java/org/jboss/hal/ballroom/form/PatternValidation.java
+++ b/ballroom/src/main/java/org/jboss/hal/ballroom/form/PatternValidation.java
@@ -1,0 +1,37 @@
+package org.jboss.hal.ballroom.form;
+
+import org.jboss.hal.resources.Messages;
+
+import com.google.gwt.core.client.GWT;
+
+public class PatternValidation implements FormItemValidation<Object> {
+
+    private final static Messages MESSAGES = GWT.create(Messages.class);
+
+    private String pattern;
+
+    public PatternValidation(String pattern) {
+        this.pattern = pattern;
+    }
+
+    @Override
+    public ValidationResult validate(Object value) {
+        return value.toString().matches(pattern) ? ValidationResult.OK : ValidationResult.invalid(errorMessage());
+    }
+
+    protected String errorMessage() {
+        return MESSAGES.invalidFormat();
+    }
+
+    public static class JNDINameValidation extends PatternValidation {
+
+        public JNDINameValidation() {
+            super("java:(jboss)?/.*");
+        }
+
+        @Override
+        protected String errorMessage() {
+            return MESSAGES.invalidJNDIName();
+        }
+    }
+}

--- a/resources/src/main/java/org/jboss/hal/resources/Messages.java
+++ b/resources/src/main/java/org/jboss/hal/resources/Messages.java
@@ -175,6 +175,8 @@ public interface Messages extends com.google.gwt.i18n.client.Messages {
 
     SafeHtml invalidExtensionJson();
     SafeHtml invalidExtensionMetadata(String extensionDocumentation);
+    String invalidFormat();
+    String invalidJNDIName();
     String invalidRange(long value, long min, long max);
     String invalidateSessionTitle();
     SafeHtml invalidateSessionQuestion();

--- a/resources/src/main/resources/org/jboss/hal/resources/Messages.properties
+++ b/resources/src/main/resources/org/jboss/hal/resources/Messages.properties
@@ -134,6 +134,8 @@ invalidateSessionError=Session <strong>{0}</strong> was not invalidated. Cause: 
 invalidateSessionNotExist=Session <strong>{0}</strong> doesn''t exist.
 invalidExtensionJson=The URL could not be parsed as JSON. Please make sure the extension metadata contains valid JSON.
 invalidExtensionMetadata=The extension metadata is missing required attributes. See <a target="_blank" href="{0}">{0}</a> for more details.
+invalidFormat=Invalid format
+invalidJNDIName=JNDI name has to start with java:/ or java:jboss/
 invalidRange={0, number} is out of range\: Valid range\: {1,number} - {2,number}
 jdbcDriverDeploymentHint=To remove a JDBC driver provided as a deployment undeploy the JDBC driver artifact.
 jdbcDriverProvidedBy=The JDBC driver is provided by {0} <code>{1}</code>.


### PR DESCRIPTION
Added validation to the datasource wizard - JNDI name has to begin with "java:/" or "java:jboss/" and Driver name has to correspond to an existing driver.

Fixed "Test connection" in the wizard and in the datasource menu - it was only working in domain and only for non-XA datasources.